### PR TITLE
Fix problem with handling of symbol-based groups

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,4 +15,4 @@ rescue LoadError
   puts "rubocop not loaded"
 end
 
-task default: [:rubocop, :spec]
+task default: %i[rubocop spec]

--- a/flippant.gemspec
+++ b/flippant.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "flippant/version"

--- a/lib/flippant/adapters/memory.rb
+++ b/lib/flippant/adapters/memory.rb
@@ -99,7 +99,7 @@ module Flippant
       end
 
       def remove_values(rules, group, values)
-        rules[group] = (rules[group] - values)
+        rules[group.to_s] = (rules[group.to_s] - values)
       end
     end
   end

--- a/spec/flippant_spec.rb
+++ b/spec/flippant_spec.rb
@@ -150,6 +150,15 @@
         )
       end
 
+      it "allows symbol-based group names" do
+        Flippant.enable("search", :members, [1])
+        Flippant.disable("search", :members, [1])
+
+        expect(Flippant.breakdown).to eq(
+          "search" => {"members" => []}
+        )
+      end
+
       it "operates atomically to avoid race conditions" do
         Flippant.enable("search", "members", [1, 2, 3, 4, 5])
 


### PR DESCRIPTION
While Flippant accommodates symbol-based group identifiers throughout, it doesn't anticipate them when you ask it to disable a feature for individual members of a group. This patch converts the symbol to a string in such cases, similarly to the rest of the library.