### PR TITLE
Stop initializing connection pool for Postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* [Flippant::Adapter::Postgres] - Pool is no longer initialized to
+  `ActiveModel::Base.connection_pool` to prevent an issue where the pool
+  was being set before Active Model has a connection
+
 ## v0.9.0 2018-03-20
 
 ### Enhancements

--- a/lib/flippant.rb
+++ b/lib/flippant.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "forwardable"
 
 module Flippant
   autoload :Error, "flippant/errors"

--- a/lib/flippant/adapters/postgres.rb
+++ b/lib/flippant/adapters/postgres.rb
@@ -8,7 +8,7 @@ module Flippant
     class Postgres
       DEFAULT_TABLE = "flippant_features"
 
-      attr_reader :pool, :table
+      attr_reader :table
 
       def initialize(table: DEFAULT_TABLE)
         @table = table
@@ -139,7 +139,7 @@ module Flippant
       private
 
       def conn
-        ActiveRecord::Base.connection_pool.with_connection do |connection|
+        pool.with_connection do |connection|
           client = connection.raw_connection
 
           yield client
@@ -154,6 +154,10 @@ module Flippant
             client.exec_params(sql, params)
           end
         end
+      end
+
+      def pool
+        ActiveRecord::Base.connection_pool
       end
 
       def transaction(&block)

--- a/lib/flippant/adapters/postgres.rb
+++ b/lib/flippant/adapters/postgres.rb
@@ -10,8 +10,7 @@ module Flippant
 
       attr_reader :pool, :table
 
-      def initialize(pool: ActiveRecord::Base.connection_pool, table: DEFAULT_TABLE)
-        @pool = pool
+      def initialize(table: DEFAULT_TABLE)
         @table = table
       end
 
@@ -140,7 +139,7 @@ module Flippant
       private
 
       def conn
-        pool.with_connection do |connection|
+        ActiveRecord::Base.connection_pool.with_connection do |connection|
           client = connection.raw_connection
 
           yield client

--- a/lib/flippant/adapters/redis.rb
+++ b/lib/flippant/adapters/redis.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "redis"
+require "forwardable"
 
 module Flippant
   module Adapter


### PR DESCRIPTION
Initializing the connection pool to `ActiveRecord::Base.connetion_pool` seems to have cause a race condition where Active Record would attempt to give a connection before `connection` is set.